### PR TITLE
feat: delete --all オプションを追加

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+Copyright © 2025 Sottiki
 */
 package cmd
 
@@ -12,23 +12,44 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
 	Use:   "delete [task ID]",
-	Short: "Delete a docket from the list",
-	Long: `Delete a docket from the list
-		For example:
-		$ docketpunch delete "1"`,
-	Args: cobra.ExactArgs(1),
+	Short: "指定したタスクを削除する",
+	Long: `指定したIDのタスクを削除します。
+--all フラグを指定すると全タスクを削除します（連番はリセットしません）。
+$ docket delete 1
+$ docket delete --all`,
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		taskID, err := strconv.Atoi(args[0])
-		if err != nil {
-			log.Fatalf("Invalid task ID: %s\n", args[0])
-		}
+		all, _ := cmd.Flags().GetBool("all")
 
 		docket, err := storage.Load()
 		if err != nil {
 			log.Fatalf("Failed to load data: %v\n", err)
+		}
+
+		if all {
+			count := len(docket.Tasks)
+			if count == 0 {
+				fmt.Println("No tasks to delete.")
+				return
+			}
+			docket.DeleteAllTasks()
+			if err := storage.Save(docket); err != nil {
+				log.Fatal("Failed to save data:", err)
+			}
+			fmt.Printf("✓ Deleted all %d tasks.\n", count)
+			return
+		}
+
+		if len(args) == 0 {
+			fmt.Println("task ID を指定してください。全削除は --all を使用してください。")
+			return
+		}
+
+		taskID, err := strconv.Atoi(args[0])
+		if err != nil {
+			log.Fatalf("Invalid task ID: %s\n", args[0])
 		}
 
 		deletedTask, success := docket.DeleteTask(taskID)
@@ -46,14 +67,5 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(deleteCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// deleteCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// deleteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	deleteCmd.Flags().Bool("all", false, "全タスクを削除する（連番はリセットしない）")
 }


### PR DESCRIPTION
全タスク削除（NextID は維持）。DeleteAllTasks() を docket に追加し
delete コマンドに --all フラグを実装