### PR TITLE
refactor: formatTaskAsTicket を formatter.go に分離

### DIFF
--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -1,0 +1,28 @@
+/*
+Copyright © 2025 Sottiki
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/Sottiki/docketpunch/internal/task"
+)
+
+func formatTaskAsTicket(t *task.Task) string {
+	statusMark := " "
+	if t.Done {
+		statusMark = "◯"
+	}
+
+	createDate := t.CreatedAt.Format("01/02")
+
+	var dateInfo string
+	if t.Done && t.CompletedAt != nil {
+		completeDate := t.CompletedAt.Format("01/02")
+		dateInfo = fmt.Sprintf("(%s→%s)", createDate, completeDate)
+	} else {
+		dateInfo = fmt.Sprintf("(%s)", createDate)
+	}
+	return fmt.Sprintf("[ %s|#%d|%s %s]", statusMark, t.ID, t.Description, dateInfo)
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -8,16 +8,14 @@ import (
 	"log"
 
 	"github.com/Sottiki/docketpunch/internal/storage"
-	"github.com/Sottiki/docketpunch/internal/task"
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all tasks",
 	Long: `List all tasks in ticket format.
-	
+
 Example:
   docket list`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -39,24 +37,4 @@ Example:
 
 func init() {
 	rootCmd.AddCommand(listCmd)
-}
-
-// タスクをチケット形式で表示する
-func formatTaskAsTicket(t *task.Task) string {
-	statusMark := " "
-	if t.Done {
-		statusMark = "◯"
-	}
-
-	createDate := t.CreatedAt.Format("01/02")
-
-	var dateInfo string
-	if t.Done && t.CompletedAt != nil {
-		completeDate := t.CompletedAt.Format("01/02")
-		dateInfo = fmt.Sprintf("(%s→%s)", createDate, completeDate)
-	} else {
-		dateInfo = fmt.Sprintf("(%s)", createDate)
-	}
-	return fmt.Sprintf("[ %s|#%d|%s %s]", statusMark, t.ID, t.Description, dateInfo)
-
 }


### PR DESCRIPTION
list.go に混在していた表示ヘルパーを cmd/formatter.go に切り出し
責務を明確化