### PR TITLE
fix: 完了マークを ◯ から o に変更

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -130,8 +130,8 @@ func TestPunchCmd_ShowsListAfterPunch(t *testing.T) {
 	run("add", "タスクA")
 	out := run("punch")
 
-	if !strings.Contains(out, "◯") {
-		t.Errorf("punch output should show completed mark ◯, got: %s", out)
+	if !strings.Contains(out, "o") {
+		t.Errorf("punch output should show completed mark o, got: %s", out)
 	}
 }
 
@@ -252,8 +252,8 @@ func TestFormatTaskAsTicket_Completed(t *testing.T) {
 	run("punch", "1")
 	out := run("list")
 
-	if !strings.Contains(out, "◯") {
-		t.Errorf("completed task should show ◯ mark, got: %s", out)
+	if !strings.Contains(out, "o") {
+		t.Errorf("completed task should show o mark, got: %s", out)
 	}
 	if !strings.Contains(out, "→") {
 		t.Errorf("completed task should show created→completed dates, got: %s", out)

--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -12,7 +12,7 @@ import (
 func formatTaskAsTicket(t *task.Task) string {
 	statusMark := " "
 	if t.Done {
-		statusMark = "◯"
+		statusMark = "o"
 	}
 
 	createDate := t.CreatedAt.Format("01/02")


### PR DESCRIPTION
Windows 環境でのフォント非対応による文字化けを解消 パンチカードの「穴」を o で表現しコンセプトも維持

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>