### PR TITLE
feat: list --done / --pending フィルタフラグを追加

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -98,6 +98,77 @@ func TestListCmd_ShowsTicketFormat(t *testing.T) {
 	}
 }
 
+func TestListCmd_DoneFlag_ShowsOnlyCompleted(t *testing.T) {
+	withTempHome(t)
+
+	run("add", "未完了タスク")
+	run("add", "完了タスク")
+	run("punch", "2")
+
+	out := run("list", "--done")
+
+	if !strings.Contains(out, "#2") {
+		t.Errorf("--done should show completed task #2, got: %s", out)
+	}
+	if strings.Contains(out, "#1") {
+		t.Errorf("--done should not show pending task #1, got: %s", out)
+	}
+}
+
+func TestListCmd_PendingFlag_ShowsOnlyPending(t *testing.T) {
+	withTempHome(t)
+
+	run("add", "未完了タスク")
+	run("add", "完了タスク")
+	run("punch", "2")
+
+	out := run("list", "--pending")
+
+	if !strings.Contains(out, "#1") {
+		t.Errorf("--pending should show pending task #1, got: %s", out)
+	}
+	if strings.Contains(out, "#2") {
+		t.Errorf("--pending should not show completed task #2, got: %s", out)
+	}
+}
+
+func TestListCmd_DoneFlag_EmptyResult(t *testing.T) {
+	withTempHome(t)
+
+	run("add", "未完了のみ")
+
+	out := run("list", "--done")
+
+	if !strings.Contains(out, "No tasks found") {
+		t.Errorf("--done with no completed tasks should show 'No tasks found', got: %s", out)
+	}
+}
+
+func TestListCmd_PendingFlag_EmptyResult(t *testing.T) {
+	withTempHome(t)
+
+	run("add", "完了のみ")
+	run("punch", "1")
+
+	out := run("list", "--pending")
+
+	if !strings.Contains(out, "No tasks found") {
+		t.Errorf("--pending with all tasks done should show 'No tasks found', got: %s", out)
+	}
+}
+
+func TestListCmd_BothFlags_Error(t *testing.T) {
+	withTempHome(t)
+
+	run("add", "タスク")
+
+	out := run("list", "--done", "--pending")
+
+	if !strings.Contains(out, "cannot use --done and --pending together") {
+		t.Errorf("using both flags should show error message, got: %s", out)
+	}
+}
+
 // --- punch ---
 
 func TestPunchCmd_NoArgs_PunchesLatest(t *testing.T) {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -8,33 +8,67 @@ import (
 	"log"
 
 	"github.com/Sottiki/docketpunch/internal/storage"
+	"github.com/Sottiki/docketpunch/internal/task"
 	"github.com/spf13/cobra"
 )
 
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all tasks",
-	Long: `List all tasks in ticket format.
+	Long: `List tasks in ticket format.
 
 Example:
-  docket list`,
+  docket list
+  docket list --done
+  docket list --pending`,
 	Run: func(cmd *cobra.Command, args []string) {
+		doneOnly, _ := cmd.Flags().GetBool("done")
+		pendingOnly, _ := cmd.Flags().GetBool("pending")
+		defer func() {
+			_ = cmd.Flags().Set("done", "false")
+			_ = cmd.Flags().Set("pending", "false")
+		}()
+
+		if doneOnly && pendingOnly {
+			fmt.Println("cannot use --done and --pending together")
+			return
+		}
+
 		docket, err := storage.Load()
 		if err != nil {
 			log.Fatalf("Failed to load data: %v", err)
 		}
 
-		if len(docket.Tasks) == 0 {
+		tasks := filterTasks(docket.Tasks, doneOnly, pendingOnly)
+		if len(tasks) == 0 {
 			fmt.Println("No tasks found")
 			return
 		}
 
-		for _, t := range docket.Tasks {
+		for _, t := range tasks {
 			fmt.Println(formatTaskAsTicket(t))
 		}
 	},
 }
 
+func filterTasks(tasks []*task.Task, doneOnly, pendingOnly bool) []*task.Task {
+	if !doneOnly && !pendingOnly {
+		return tasks
+	}
+	filtered := make([]*task.Task, 0, len(tasks))
+	for _, t := range tasks {
+		if doneOnly && t.Done {
+			filtered = append(filtered, t)
+		}
+		if pendingOnly && !t.Done {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
 func init() {
 	rootCmd.AddCommand(listCmd)
+	listCmd.Flags().Bool("done", false, "完了したタスクのみ表示")
+	listCmd.Flags().Bool("pending", false, "未完了のタスクのみ表示")
 }


### PR DESCRIPTION
## Summary
- `list --done`: 完了済みタスクのみ表示
- `list --pending`: 未完了タスクのみ表示
- 両フラグ同時使用時はエラーメッセージを表示

## Test plan
- [x] `go test ./...` 全テスト通過
- [x] TestListCmd_DoneFlag_ShowsOnlyCompleted
- [x] TestListCmd_PendingFlag_ShowsOnlyPending
- [x] TestListCmd_DoneFlag_EmptyResult
- [x] TestListCmd_PendingFlag_EmptyResult
- [x] TestListCmd_BothFlags_Error