### PR TITLE
feat: edit コマンドを追加（タスクの説明文を編集）

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -331,6 +331,66 @@ func TestFormatTaskAsTicket_Completed(t *testing.T) {
 	}
 }
 
+// --- edit ---
+
+func TestEditCmd_EditsDescription(t *testing.T) {
+	withTempHome(t)
+
+	run("add", "元のタスク")
+	out := run("edit", "1", "編集後のタスク")
+
+	if !strings.Contains(out, "Edited task #1") {
+		t.Errorf("edit output should contain 'Edited task #1', got: %s", out)
+	}
+	if !strings.Contains(out, "編集後のタスク") {
+		t.Errorf("edit output should contain new description, got: %s", out)
+	}
+
+	listOut := run("list")
+	if !strings.Contains(listOut, "編集後のタスク") {
+		t.Errorf("after edit, list should show new description, got: %s", listOut)
+	}
+	if strings.Contains(listOut, "元のタスク") {
+		t.Errorf("after edit, list should not show old description, got: %s", listOut)
+	}
+}
+
+func TestEditCmd_NotFound(t *testing.T) {
+	withTempHome(t)
+
+	out := run("edit", "999", "存在しない")
+
+	if !strings.Contains(out, "Task #999 not found") {
+		t.Errorf("edit on non-existent ID should show 'Task #999 not found', got: %s", out)
+	}
+}
+
+func TestEditCmd_ShowsListAfterEdit(t *testing.T) {
+	withTempHome(t)
+
+	run("add", "タスクA")
+	run("add", "タスクB")
+	out := run("edit", "1", "更新済みタスク")
+
+	if !strings.Contains(out, "#1") || !strings.Contains(out, "#2") {
+		t.Errorf("edit output should show full ticket list with #1 and #2, got: %s", out)
+	}
+	if !strings.Contains(out, "[") {
+		t.Errorf("edit output should show ticket format, got: %s", out)
+	}
+}
+
+func TestEditCmd_MultiWordDescription(t *testing.T) {
+	withTempHome(t)
+
+	run("add", "old")
+	out := run("edit", "1", "new", "multi", "word", "description")
+
+	if !strings.Contains(out, "new multi word description") {
+		t.Errorf("edit should join multi-word args with spaces, got: %s", out)
+	}
+}
+
 // --- stderr を捨てる helper（log.Fatalf による os.Exit を回避するためテストは正常系のみ） ---
 
 func init() {

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,0 +1,54 @@
+/*
+Copyright © 2025 Sottiki
+*/
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/Sottiki/docketpunch/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+var editCmd = &cobra.Command{
+	Use:   "edit <id> <description>",
+	Short: "タスクの説明文を編集する",
+	Long: `指定したIDのタスクの説明文を編集します。
+$ docket edit 1 新しい説明文`,
+	Args: cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		taskID, err := strconv.Atoi(args[0])
+		if err != nil {
+			log.Fatalf("Invalid task ID: %s", args[0])
+		}
+
+		newDescription := strings.Join(args[1:], " ")
+
+		docket, err := storage.Load()
+		if err != nil {
+			log.Fatalf("Failed to load data: %v", err)
+		}
+
+		editedTask, ok := docket.EditTask(taskID, newDescription)
+		if !ok {
+			fmt.Printf("Task #%d not found\n", taskID)
+			return
+		}
+
+		if err := storage.Save(docket); err != nil {
+			log.Fatalf("Failed to save data: %v", err)
+		}
+
+		fmt.Printf("Edited task #%d: %s\n", editedTask.ID, editedTask.Description)
+		for _, t := range docket.Tasks {
+			fmt.Println(formatTaskAsTicket(t))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(editCmd)
+}

--- a/internal/docket/docket.go
+++ b/internal/docket/docket.go
@@ -48,6 +48,16 @@ func (d *Docket) GetLatestIncompleteTask() *task.Task {
 	return nil
 }
 
+func (d *Docket) EditTask(id int, newDescription string) (*task.Task, bool) {
+	for _, t := range d.Tasks {
+		if t.ID == id {
+			t.Description = newDescription
+			return t, true
+		}
+	}
+	return nil, false
+}
+
 func (d *Docket) DeleteTask(id int) (*task.Task, bool) {
 	for i, t := range d.Tasks {
 		if t.ID == id {

--- a/internal/docket/docket_test.go
+++ b/internal/docket/docket_test.go
@@ -182,6 +182,39 @@ func TestDocket_DeleteTask(t *testing.T) {
 	}
 }
 
+func TestDocket_EditTask(t *testing.T) {
+	d := NewDocket()
+	d.AddTask("Task 1")
+	d.AddTask("Task 2")
+
+	edited, ok := d.EditTask(1, "Updated task")
+
+	if !ok {
+		t.Fatal("EditTask(1) returned false, want true")
+	}
+
+	if edited == nil {
+		t.Fatal("EditTask(1) returned nil task")
+	}
+
+	if edited.Description != "Updated task" {
+		t.Errorf("Edited task description = %s, want %s", edited.Description, "Updated task")
+	}
+
+	if d.Tasks[0].Description != "Updated task" {
+		t.Errorf("Tasks[0].Description = %s, want %s", d.Tasks[0].Description, "Updated task")
+	}
+
+	if d.Tasks[1].Description != "Task 2" {
+		t.Errorf("Tasks[1].Description = %s, want %s (should be unchanged)", d.Tasks[1].Description, "Task 2")
+	}
+
+	_, ok = d.EditTask(999, "no such task")
+	if ok {
+		t.Error("EditTask on non-existent ID should return false")
+	}
+}
+
 func TestDocket_ResetDocket(t *testing.T) {
 	d := NewDocket()
 	d.AddTask("Task 1")


### PR DESCRIPTION
## 概要

タスクの説明文を編集できる `edit` コマンドを追加

## 変更内容

- `docket edit <id> <新しい説明>` でタスクの説明文を上書き
- 編集後に全タスク一覧を表示（`add` / `punch` と同じ UX）
- 存在しない ID を指定した場合はエラーメッセージを表示
- スペースを含む説明も複数引数で渡せる（例: `docket edit 1 新しい 説明 文`）

## 使用例

`$ docket add "古いタスク名"`  
`$ docket edit 1 新しいタスク名`  
`Edited task #1: 新しいタスク名`
 > [ |#1|新しいタスク名 (05/10)]

## テスト

- [x] `go test ./...` 全テスト通過
- [x] 正常編集・説明文の反映確認
- [x] 存在しない ID へのエラー表示
- [x] 編集後の一覧表示
- [x] 複数単語をスペース結合